### PR TITLE
Update Scapix

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -48,7 +48,7 @@ jobs:
       - uses: nttld/setup-ndk@v1
         id: setup-ndk
         with:
-          ndk-version: r23b
+          ndk-version: r25
           add-to-path: false
 
       - name: Cache native-build-related files
@@ -57,7 +57,7 @@ jobs:
           path: |
             ~/.cmodule
             ${{github.workspace}}/${{env.NATIVE_PROJECT_SUBDIR}}/${{env.BUILD_SUBDIR}}
-          key: ${{runner.os}}-native-build-cache
+          key: ${{runner.os}}-native
 
       - name: Prepare OpenCV
         env:

--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -41,7 +41,7 @@ jobs:
         run: cmake --build ${{env.BUILD_SUBDIR}} --config ${{env.BUILD_TYPE}}
 
   build-java-bridge:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     env:
       CC: clang

--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ${{github.workspace}}/${{env.PROJECT_SUBDIR}}/${{env.BUILD_SUBDIR}}
-          key: ${{runner.os}}-build-cache-v5
+          key: ${{runner.os}}-native
 
       - name: Prepare OpenCV
         run: cmake -P BuildOpenCV.cmake
@@ -41,7 +41,7 @@ jobs:
         run: cmake --build ${{env.BUILD_SUBDIR}} --config ${{env.BUILD_TYPE}}
 
   build-java-bridge:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-22.04  # Distribution with clang 14 or later is required for Scapix
 
     env:
       CC: clang
@@ -58,7 +58,7 @@ jobs:
           path: |
             ~/.cmodule
             ${{github.workspace}}/${{env.PROJECT_SUBDIR}}/${{env.BUILD_SUBDIR}}
-          key: ${{runner.os}}-build-cache-bridge
+          key: ${{runner.os}}-bridge
 
       - name: Prepare OpenCV
         run: cmake -P BuildOpenCV.cmake
@@ -83,7 +83,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ${{github.workspace}}/${{env.PROJECT_SUBDIR}}/${{env.BUILD_SUBDIR}}
-          key: ${{runner.os}}-build-cache-v5
+          key: ${{runner.os}}-native
 
       - name: Configure linters
         run: |

--- a/sgbmdepth/build.gradle
+++ b/sgbmdepth/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 android {
     compileSdk 31
-    ndkVersion '23.1.7779620'
+    ndkVersion '25.0.8775105'
 
     namespace 'me.timpushkin.sgbmdepth'
 

--- a/sgbmdepth/src/main/cpp/CMakeLists.txt
+++ b/sgbmdepth/src/main/cpp/CMakeLists.txt
@@ -19,11 +19,6 @@ add_subdirectory(src)
 add_subdirectory(external)
 
 if (BUILD_EXAMPLES)
-    if (NOT DEFINED SCAPIX_BRIDGE)
-        message(STATUS "Will build examples")
-        add_subdirectory(examples)
-    else ()
-        # Currently Scapix adds unwanted files to the 'examples' target
-        message(WARNING "Cannot build examples when Scapix is used")
-    endif ()
+    message(STATUS "Will build examples")
+    add_subdirectory(examples)
 endif ()

--- a/sgbmdepth/src/main/cpp/README.md
+++ b/sgbmdepth/src/main/cpp/README.md
@@ -38,6 +38,10 @@ The project consists of the following directories:
 
 ## Build
 
+**Note**: when building on Windows, you may be required to specify a non-default generator, for
+example, `ninja`, with `-DCMAKE_GENERATOR=<generator name>` in the configuration command, because
+Windows' default generator `nmake` seems to fail.
+
 This project requires [OpenCV](https://github.com/opencv/opencv) 4.5.5 or later. You can either
 manually download and install it, or run `BuildOpenCV.cmake` script that will download and build
 OpenCV for you.
@@ -49,10 +53,6 @@ If you already have OpenCV, you can build this project with CMake:
 cmake .          # Configure the build
 cmake --build .  # Start the build
 ```
-
-*Note*: when building on Windows, you may be required to specify a non-default generator, for
-example, `ninja`, with `-DCMAKE_GENERATOR=<generator name>` in the configuration command, because
-Windows' default generator `nmake` seems to fail.
 
 ### Running OpenCV build script
 
@@ -89,16 +89,19 @@ For example, if you want to build for Android with ABI `armeabi-v7a` and Neon su
 installed in the system, the command to run the script will be something like:
 
 ```shell
-cmake -DCMAKE_TOOLCHAIN_FILE="<NDK path>/build/cmake/android.toolchain.cmake" \
-      -DCMAKE_C_COMPILER="<NDK path>/toolchains/llvm/prebuilt/<platform>/bin/clang<extension>" \
-      -DCMAKE_CXX_COMPILER="<NDK path>/toolchains/llvm/prebuilt/<platform>/bin/clang++<extension>" \
-      -DANDROID_ABI=armeabi-v7a \
-      -DANDROID_ARM_NEON=ON \
-      -DADD_ANDROID_ABI_CHECK=ON \
+cmake -D CMAKE_TOOLCHAIN_FILE="<NDK path>/build/cmake/android.toolchain.cmake" \
+      -D CMAKE_C_COMPILER="<NDK path>/toolchains/llvm/prebuilt/<platform>/bin/clang<extension>" \
+      -D CMAKE_CXX_COMPILER="<NDK path>/toolchains/llvm/prebuilt/<platform>/bin/clang++<extension>" \
+      -D ANDROID_ABI=armeabi-v7a \
+      -D ANDROID_ARM_NEON=ON \
+      -D ADD_ANDROID_ABI_CHECK=ON \
       -P BuildOpenCV.cmake
 ```
 
 ### Generating a language interface
+
+**Note**: this requires `clang-14.0.0` or newer to be used for building both OpenCV and the project;
+if you are building for Android, use NDK `r25` or newer.
 
 To generate an interface for Java, Objective-C, Python, and some other languages modify the
 configure command as follows:
@@ -115,7 +118,8 @@ build.
 
 ## Usage examples
 
-Files in `examples` directory demonstrate how to use this project for depth estimation.
+Files in `examples` directory demonstrate how to use this project for depth estimation. Specify
+`-D BUILD_EXAMPLES=ON` to build them.
 
 - `GetDepthExample.cpp` accepts three CLI arguments: path to the file with calibration parameters,
   path to the left image and path to the right image – using them, it estimates depth and prints the

--- a/sgbmdepth/src/main/cpp/examples/CMakeLists.txt
+++ b/sgbmdepth/src/main/cpp/examples/CMakeLists.txt
@@ -4,6 +4,6 @@ add_executable(get_depth_example GetDepthExample.cpp)
 target_link_libraries(get_depth_example ${PROJECT_NAME})
 
 # Required for CMake version less than 3.20
-if (DEFINED SCAPIX_BRIDGE)
+if (DEFINED SCAPIX_BRIDGE AND CMAKE_VERSION VERSION_LESS 3.20)
     scapix_fix_sources(${PROJECT_NAME})
 endif ()

--- a/sgbmdepth/src/main/cpp/examples/CMakeLists.txt
+++ b/sgbmdepth/src/main/cpp/examples/CMakeLists.txt
@@ -2,3 +2,8 @@
 add_executable(get_depth_example GetDepthExample.cpp)
 
 target_link_libraries(get_depth_example ${PROJECT_NAME})
+
+# Required for CMake version less than 3.20
+if (DEFINED SCAPIX_BRIDGE)
+    scapix_fix_sources(${PROJECT_NAME})
+endif ()

--- a/sgbmdepth/src/main/cpp/external/CMakeLists.txt
+++ b/sgbmdepth/src/main/cpp/external/CMakeLists.txt
@@ -3,3 +3,7 @@ add_subdirectory(opencv)
 if (ANDROID)
     add_subdirectory(log-lib)
 endif ()
+
+if (DEFINED SCAPIX_BRIDGE)
+    add_subdirectory(scapix)
+endif ()

--- a/sgbmdepth/src/main/cpp/external/scapix/CMakeLists.txt
+++ b/sgbmdepth/src/main/cpp/external/scapix/CMakeLists.txt
@@ -1,0 +1,17 @@
+message(STATUS "Configuring Scapix for ${SCAPIX_BRIDGE}")
+
+set(HEADER_FILES ${CMAKE_SOURCE_DIR}/include/DepthEstimator.h)
+
+include(FetchContent)
+FetchContent_Declare(
+        cmodule
+        URL "https://github.com/scapix-com/cmodule/archive/refs/tags/v1.0.35.tar.gz"
+        URL_HASH SHA256=3eeabad538e9e06bc21f4ccafccfa97808b8458044ee32f28a37b81e7ce8d174
+)
+FetchContent_MakeAvailable(cmodule)
+
+find_package(Scapix REQUIRED)
+
+scapix_bridge_headers(${PROJECT_NAME} me.timpushkin.sgbmdepth ${HEADER_FILES})
+
+message(STATUS "Configuring Scapix - done")

--- a/sgbmdepth/src/main/cpp/src/CMakeLists.txt
+++ b/sgbmdepth/src/main/cpp/src/CMakeLists.txt
@@ -12,8 +12,8 @@ if (DEFINED SCAPIX_BRIDGE)
     include(FetchContent)
     FetchContent_Declare(
             cmodule
-            URL "https://github.com/scapix-com/cmodule/archive/refs/tags/v1.0.32.tar.gz"  # Build fails with v1.0.33
-            URL_HASH SHA256=e6937c95d73188a5add846b27cd00160fe4f6ea31af33be417d2ab7ac19bd8d2
+            URL "https://github.com/scapix-com/cmodule/archive/refs/tags/v1.0.35.tar.gz"  # Build fails with v1.0.33
+            URL_HASH SHA256=3eeabad538e9e06bc21f4ccafccfa97808b8458044ee32f28a37b81e7ce8d174
     )
     FetchContent_MakeAvailable(cmodule)
 

--- a/sgbmdepth/src/main/cpp/src/CMakeLists.txt
+++ b/sgbmdepth/src/main/cpp/src/CMakeLists.txt
@@ -2,24 +2,3 @@ set(SOURCE_FILES DepthEstimator.cpp)
 
 add_library(${PROJECT_NAME} SHARED ${SOURCE_FILES})
 target_include_directories(${PROJECT_NAME} PUBLIC ${CMAKE_SOURCE_DIR}/include)
-
-# TODO: move Scapix configuration into `external` folder
-if (DEFINED SCAPIX_BRIDGE)
-    message(STATUS "Configuring Scapix for ${SCAPIX_BRIDGE}")
-
-    set(HEADER_FILES ${CMAKE_SOURCE_DIR}/include/DepthEstimator.h)
-
-    include(FetchContent)
-    FetchContent_Declare(
-            cmodule
-            URL "https://github.com/scapix-com/cmodule/archive/refs/tags/v1.0.35.tar.gz"  # Build fails with v1.0.33
-            URL_HASH SHA256=3eeabad538e9e06bc21f4ccafccfa97808b8458044ee32f28a37b81e7ce8d174
-    )
-    FetchContent_MakeAvailable(cmodule)
-
-    find_package(Scapix REQUIRED)
-
-    scapix_bridge_headers(${PROJECT_NAME} me.timpushkin.sgbmdepth ${HEADER_FILES})
-
-    message(STATUS "Configuring Scapix - done")
-endif ()


### PR DESCRIPTION
- Updates Scapix to the version destributed in cmodule `v1.0.35`
- Changes native library file structure fixing #8
- Updates NDK to `r25`
- Updates CI (NDK and Ubuntu where needed)

Note: it turned out that newer Scapix requires `clang 14` or newer (maybe `clang 13` is also compatible, but `11` and `12` are not) -- that is why NDK needed to be updated to `r25` and Ubuntu in CI needed to be updated to `22.04`.