### PR TITLE
Fix native `examples` building together with Scapix

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -57,7 +57,7 @@ jobs:
           path: |
             ~/.cmodule
             ${{github.workspace}}/${{env.NATIVE_PROJECT_SUBDIR}}/${{env.BUILD_SUBDIR}}
-          key: ${{runner.os}}-native
+          key: ${{runner.os}}-android
 
       - name: Prepare OpenCV
         env:

--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -14,33 +14,6 @@ defaults:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - uses: hendrikmuhs/ccache-action@v1.2
-
-      - name: Cache build artifacts
-        uses: actions/cache@v3
-        with:
-          path: ${{github.workspace}}/${{env.PROJECT_SUBDIR}}/${{env.BUILD_SUBDIR}}
-          key: ${{runner.os}}-native
-
-      - name: Prepare OpenCV
-        run: cmake -P BuildOpenCV.cmake
-
-      - name: Configure CMake
-        run: |
-          cmake -B ${{env.BUILD_SUBDIR}} \
-                -D CMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} \
-                -D CMAKE_EXPORT_COMPILE_COMMANDS=ON \
-                -D BUILD_EXAMPLES=ON
-
-      - name: Build
-        run: cmake --build ${{env.BUILD_SUBDIR}} --config ${{env.BUILD_TYPE}}
-
-  build-java-bridge:
     runs-on: ubuntu-22.04  # Distribution with clang 14 or later is required for Scapix
 
     env:
@@ -58,7 +31,7 @@ jobs:
           path: |
             ~/.cmodule
             ${{github.workspace}}/${{env.PROJECT_SUBDIR}}/${{env.BUILD_SUBDIR}}
-          key: ${{runner.os}}-bridge
+          key: ${{runner.os}}-native
 
       - name: Prepare OpenCV
         run: cmake -P BuildOpenCV.cmake
@@ -67,6 +40,8 @@ jobs:
         run: |
           cmake -B ${{env.BUILD_SUBDIR}} \
                 -D CMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} \
+                -D CMAKE_EXPORT_COMPILE_COMMANDS=ON \
+                -D BUILD_EXAMPLES=ON \
                 -D SCAPIX_BRIDGE=java
 
       - name: Build

--- a/sgbmdepth/src/main/cpp/examples/CMakeLists.txt
+++ b/sgbmdepth/src/main/cpp/examples/CMakeLists.txt
@@ -3,7 +3,7 @@ add_executable(get_depth_example GetDepthExample.cpp)
 
 target_link_libraries(get_depth_example ${PROJECT_NAME})
 
-# Required for CMake version less than 3.20
-if (DEFINED SCAPIX_BRIDGE AND CMAKE_VERSION VERSION_LESS 3.20)
+# Required when cmake_minimum_required version is less than 3.20
+if (DEFINED SCAPIX_BRIDGE)
     scapix_fix_sources(${PROJECT_NAME})
 endif ()


### PR DESCRIPTION
- Now target `examples` can be built together with Scapix bridge generation
- Native CI is simplified